### PR TITLE
remove deprecated constants Shopware::VERSION since SW 5.5

### DIFF
--- a/Controllers/Frontend/FatchipCTPayment.php
+++ b/Controllers/Frontend/FatchipCTPayment.php
@@ -365,7 +365,17 @@ abstract class Shopware_Controllers_Frontend_FatchipCTPayment extends Shopware_C
      */
     public function getUserDataParam()
     {
-        return 'Shopware Version: ' . \Shopware::VERSION . ', Modul Version: ' . $this->plugin->getVersion();;
+        $info = 'Shopware Version: %s Modul Version: %s';
+        if (Util::isShopwareVersionGreaterThanOrEqual('5.4')) {
+            //since shopware 5.4.0 DIC parameter was introduced
+            return sprintf(
+                $info,
+                $this->container->getParameter('shopware.release.version'),
+                $this->plugin->getVersion()
+            );
+        }
+
+        return sprintf($info, \Shopware::VERSION, $this->plugin->getVersion());
     }
 
     /**


### PR DESCRIPTION
this fixes a bug where the sw version will output incorrectly in api log. especially in composer projects.

before
<img width="453" alt="Bildschirmfoto 2019-04-05 um 21 26 09" src="https://user-images.githubusercontent.com/907458/55651631-8c0a6a00-57e9-11e9-9d39-a6be93e7bde6.png">

after 
<img width="406" alt="Bildschirmfoto 2019-04-05 um 21 32 27" src="https://user-images.githubusercontent.com/907458/55651932-629e0e00-57ea-11e9-8f7e-8815194e5866.png">

