### PR TITLE
add multilanguage support to computop iframes

### DIFF
--- a/Controllers/Frontend/FatchipCTPayment.php
+++ b/Controllers/Frontend/FatchipCTPayment.php
@@ -115,6 +115,8 @@ abstract class Shopware_Controllers_Frontend_FatchipCTPayment extends Shopware_C
         $this->paymentService = Shopware()->Container()->get('FatchipCTPaymentApiClient');
         $this->plugin = Shopware()->Plugins()->Frontend()->FatchipCTPayment();
         $this->config = $this->plugin->Config()->toArray();
+        //add shop language to config array to avoid more argument bloat in paymentService::getIFramePaymentClass() & CTPaymentMethods::__construct()
+        $this->config['language'] = $this->getLanguageFromCurrentShop();
         $this->utils = Shopware()->Container()->get('FatchipCTPaymentUtils');
         $this->session = Shopware()->Session();
         $this->router = $this->Front()->Router();
@@ -743,6 +745,28 @@ abstract class Shopware_Controllers_Frontend_FatchipCTPayment extends Shopware_C
             $ctOrder->setEmail($email);
         }
         return $ctOrder;
+    }
+
+    /**
+     * Try to obtain the ISO-639-1 language code for the current subshop
+     * @return string|null
+     */
+    private function getLanguageFromCurrentShop()
+    {
+        $shop = Shopware()->Shop();
+        if ($shop === null) {
+            return null;
+        }
+        $locale = $shop->getLocale();
+        if ($locale === null) {
+            return null;
+        }
+        $locale = $locale->getLocale();
+        $match = [];
+        if (!preg_match('/^(?<language>[a-z]{2,3})_(?<country>[A-Z]{2,3})$/', $locale, $match)) {
+            return null;
+        }
+        return $match['language'];
     }
 }
 


### PR DESCRIPTION
The shopware plugin will currently not pass any language parameter to CompuTop IFrames, meaning the IFrame content will always be german even if the subshop has a different language configured that computop supports.

This PR handles determining the current shop's language code and passing it to the payment method.

The library PR for using the language is here:

https://github.com/FATCHIP-GmbH/library-computop/pull/8