### PR TITLE
fix exception handling

### DIFF
--- a/Controllers/Frontend/FatchipCTCreditCard.php
+++ b/Controllers/Frontend/FatchipCTCreditCard.php
@@ -71,11 +71,18 @@ class Shopware_Controllers_Frontend_FatchipCTCreditCard extends Shopware_Control
      */
     public function gatewayAction()
     {
-        $payment = $this->getPaymentClassForGatewayAction();
-        $params = $payment->getRedirectUrlParams();
-        $this->session->offsetSet('fatchipCTRedirectParams', $params);
+        try {
+            $payment = $this->getPaymentClassForGatewayAction();
+            $params = $payment->getRedirectUrlParams();
+            $this->session->offsetSet('fatchipCTRedirectParams', $params);
 
-        $this->forward('iframe', 'FatchipCTCreditCard', null, array('fatchipCTRedirectURL' => $payment->getHTTPGetURL($params, $this->config['creditCardTemplate'])));
+            $this->forward('iframe', 'FatchipCTCreditCard', null, array('fatchipCTRedirectURL' => $payment->getHTTPGetURL($params, $this->config['creditCardTemplate'])));
+        } catch (Exception $e) {
+            $ctError = [];
+            $ctError['CTErrorMessage'] = 'Bei der Verarbeitung Ihrer Adresse ist ein Fehler aufgetreten<BR>';
+            $ctError['CTErrorCode'] = 'Bitte prüfen Sie Straße und Hausnummer';
+            return $this->forward('confirm', 'checkout', null, ['CTError' => $ctError]);
+        }
     }
 
     /**

--- a/Controllers/Frontend/FatchipCTPayment.php
+++ b/Controllers/Frontend/FatchipCTPayment.php
@@ -305,16 +305,16 @@ abstract class Shopware_Controllers_Frontend_FatchipCTPayment extends Shopware_C
         $ctOrder = new CTOrder();
         $ctOrder->setAmount($this->getAmount() * 100);
         $ctOrder->setCurrency($this->getCurrencyShortName());
-        // try catch in case Address Splitter retrun exceptions
-        try {
-            $ctOrder->setBillingAddress($this->utils->getCTAddress($userData['billingaddress']));
-            $ctOrder->setShippingAddress($this->utils->getCTAddress($userData['shippingaddress']));
-        } catch (Exception $e) {
-            $ctError = [];
-            $ctError['CTErrorMessage'] = 'Bei der Verarbeitung Ihrer Adresse ist ein Fehler aufgetreten<BR>';
-            $ctError['CTErrorCode'] = $e->getMessage();
-            return $this->forward('shippingPayment', 'checkout', null, ['CTError' => $ctError]);
+
+        //handle expired session
+        if (!array_key_exists('billingaddress', $userData)
+            || !array_key_exists('shippingaddress', $userData)
+        ) {
+            throw new Exception('Ihre Sitzung ist abgelaufen. Bitte loggen Sie sich erneut ein.');
         }
+
+        $ctOrder->setBillingAddress($this->utils->getCTAddress($userData['billingaddress']));
+        $ctOrder->setShippingAddress($this->utils->getCTAddress($userData['shippingaddress']));
         $ctOrder->setEmail($userData['additional']['user']['email']);
         $ctOrder->setCustomerID($userData['additional']['user']['id']);
         // Mandatory for paypalStandard

--- a/Subscribers/Checkout.php
+++ b/Subscribers/Checkout.php
@@ -291,19 +291,24 @@ class Checkout implements SubscriberInterface
             $view->extendsTemplate('frontend/checkout/creditcard_confirm.tpl');
         }
 
-        if ($request->getActionName() == 'confirm' && (strpos($paymentName, fatchip_computop) === 0)) {
+        if ($request->getActionName() == 'confirm' && (strpos($paymentName, 'fatchip_computop') === 0)) {
             // check for address splitting errors and handle them here
             $util = new Util();
             $ctOrder = new CTOrder();
             try {
+                //handle expired session
+                if (!array_key_exists('billingaddress', $userData)
+                    || !array_key_exists('shippingaddress', $userData)
+                ) {
+                    throw new \Exception('Ihre Sitzung ist abgelaufen. Bitte loggen Sie sich erneut ein.');
+                }
                 $ctOrder->setBillingAddress($util->getCTAddress($userData['billingaddress']));
                 $ctOrder->setShippingAddress($util->getCTAddress($userData['shippingaddress']));
             } catch (\Exception $e) {
 
                 $ctError = [];
-                $ctError['CTErrorMessage'] = 'Bei der Verarbeitung Ihrer Adresse ist ein Fehler aufgetreten <BR>';
+                $ctError['CTErrorMessage'] = 'Bei der Verarbeitung Ihrer Adresse ist ein Fehler aufgetreten. <BR>';
                 $ctError['CTErrorCode'] = 'Bitte prüfen Sie Straße und Hausnummer';
-                //$subject->forward('shippingPayment', 'checkout', null, ['CTError' => $ctError]);
                 $view->assign('CTError', $ctError);
                 return;
 

--- a/Views/responsive/frontend/checkout/confirm.tpl
+++ b/Views/responsive/frontend/checkout/confirm.tpl
@@ -4,7 +4,7 @@
     {$smarty.block.parent}
     <div>
         {if $CTError}
-            {include file="frontend/_includes/messages.tpl" content="{$CTError.CTErrorMessage}:{$CTError.CTErrorCode}" type="error" bold=false}
+            {include file="frontend/_includes/messages.tpl" content="{$CTError.CTErrorMessage} {$CTError.CTErrorCode}" type="error" bold=false}
         {/if}
     </div>
 {/block}

--- a/Views/responsive/frontend/checkout/creditcard_confirm.tpl
+++ b/Views/responsive/frontend/checkout/creditcard_confirm.tpl
@@ -1,5 +1,14 @@
 {extends file="parent:frontend/checkout/confirm.tpl"}
 
+{block name='frontend_checkout_confirm_error_messages'}
+    {$smarty.block.parent}
+    <div>
+        {if $CTError}
+            {include file="frontend/_includes/messages.tpl" content="{$CTError.CTErrorMessage} {$CTError.CTErrorCode}" type="error" bold=false}
+        {/if}
+    </div>
+{/block}
+
 {block name="frontend_checkout_confirm_information_wrapper"}
     {$smarty.block.parent}
 

--- a/Views/responsive/frontend/checkout/easycredit_confirm.tpl
+++ b/Views/responsive/frontend/checkout/easycredit_confirm.tpl
@@ -1,5 +1,14 @@
 {extends file="parent:frontend/checkout/confirm.tpl"}
 
+{block name='frontend_checkout_confirm_error_messages'}
+    {$smarty.block.parent}
+    <div>
+        {if $CTError}
+            {include file="frontend/_includes/messages.tpl" content="{$CTError.CTErrorMessage} {$CTError.CTErrorCode}" type="error" bold=false}
+        {/if}
+    </div>
+{/block}
+
 {block name="frontend_checkout_confirm_product_table"}
     {if $FatchipComputopEasyCreditInformation}
         <div class='panel has--border'>

--- a/Views/responsive/frontend/checkout/shipping_payment.tpl
+++ b/Views/responsive/frontend/checkout/shipping_payment.tpl
@@ -3,7 +3,7 @@
 {block name='frontend_account_payment_error_messages'}
     <div>
         {if $CTError}
-            {include file="frontend/_includes/messages.tpl" content="{$CTError.CTErrorMessage}:{$CTError.CTErrorCode}" type="error" bold=false}
+            {include file="frontend/_includes/messages.tpl" content="{$CTError.CTErrorMessage} {$CTError.CTErrorCode}" type="error" bold=false}
         {/if}
     </div>
     {$smarty.block.parent}


### PR DESCRIPTION
The exception handling does not work as intended. There is an exception thrown by the AddressSplitter in case the street cannot be parsed. The controller tries to forward back to the payment action and display a user error, however the code executed afterwards tries to access methods on the CTOrder object, which is null in that case, resulting in this error:

```
ERROR: Uncaught Exception Error: "Call to a member function getAmount() on null" at /var/www/zooroyal/htdocs/engine/Shopware/Plugins/Local/Frontend/FatchipCTPayment/Components/Api/lib/CTPayment/CTPaymentMethodIframe.php line 177 {"exception":"Class: Error Message: Call to a member function getAmount() on null Stack Trace: #0 /var/www/zooroyal/htdocs/engine/Shopware/Plugins/Local/Frontend/FatchipCTPayment/Components/Api/lib/CTPayment/CTPaymentMethodsIframe/CreditCard.php(266): Fatchip\\CTPayment\\CTPaymentMethodIframe->__construct(Array, NULL, 'CZ', 'Shopware Versio...')\n#1 /var/www/zooroyal/htdocs/engine/Shopware/Plugins/Local/Frontend/FatchipCTPayment/Components/Api/lib/CTPayment/CTPaymentService.php(87): Fatchip\\CTPayment\\CTPaymentMethodsIframe\\CreditCard->__construct(Array, NULL, 'https://czdev.z...', 'https://czdev.z...', 'https://czdev.z...', 'CZ', 'Shopware Versio...', NULL, NULL, NULL)\n#2 /var/www/zooroyal/htdocs/engine/Shopware/Plugins/Local/Frontend/FatchipCTPayment/Controllers/Frontend/FatchipCTPayment.php(279): Fatchip\\CTPayment\\CTPaymentService->getIframePaymentClass('CreditCard', Array, NULL, 'https://czdev.z...', 'https://czdev.z...', 'https://czdev.z...', 'CZ', 'Shopware Versio...')\n#3 /var/www/zooroyal/htdocs/engine/Shopware/Plugins/Local/Frontend/FatchipCTPayment/Controllers/Frontend/FatchipCTCreditCard.php(63): Shopware_Controllers_Frontend_FatchipCTPayment->getPaymentClassForGatewayAction()
```

Another case that is not handled properly is a timed out session, resulting in this error:

```
ERROR: Uncaught Exception TypeError: "Argument 1 passed to Shopware\Plugins\FatchipCTPayment\Util::getCTAddress() must be of the type array, null given, called in /var/www/zooroyal/htdocs/engine/Shopware/Plugins/Local/Frontend/FatchipCTPayment/Controllers/Frontend/FatchipCTPayment.php on line 301" at /var/www/zooroyal/htdocs/engine/Shopware/Plugins/Local/Frontend/FatchipCTPayment/Util.php line 72 {"exception":"Class: TypeError Message: Argument 1 passed to Shopware\\Plugins\\FatchipCTPayment\\Util::getCTAddress() must be of the type array, null given, called in /var/www/zooroyal/htdocs/engine/Shopware/Plugins/Local/Frontend/FatchipCTPayment/Controllers/Frontend/FatchipCTPayment.php on line 301 Stack Trace: #0 /var/www/zooroyal/htdocs/engine/Shopware/Plugins/Local/Frontend/FatchipCTPayment/Controllers/Frontend/FatchipCTPayment.php(301): Shopware\\Plugins\\FatchipCTPayment\\Util->getCTAddress(NULL)\n#1 /var/www/zooroyal/htdocs/engine/Shopware/Plugins/Local/Frontend/FatchipCTPayment/Controllers/Frontend/FatchipCTPayment.php(272): Shopware_Controllers_Frontend_FatchipCTPayment->createCTOrder()\n#2 /var/www/zooroyal/htdocs/engine/Shopware/Plugins/Local/Frontend/FatchipCTPayment/Controllers/Frontend/FatchipCTCreditCard.php(63): Shopware_Controllers_Frontend_FatchipCTPayment->getPaymentClassForGatewayAction()
```

Even if the forward worked, the user would be forwarded to the checkout/shippingPayment action, where only the payment method can be changed, but the address cannot be corrected.
This patch forwards to checkout/confirm instead.

The patch is not perfect, for example there is only one error message displayed and that is not even translated. But maybe it's useful.
We've had several users stuck in checkout limbo in production, so it's definitely worth looking into.