### PR TITLE
fix problems with external Klarna Payments plugins

### DIFF
--- a/Subscribers/Frontend/KlarnaPayments.php
+++ b/Subscribers/Frontend/KlarnaPayments.php
@@ -92,7 +92,7 @@ class KlarnaPayments extends AbstractSubscriber
         $userData = Shopware()->Modules()->Admin()->sGetUserData();
         $paymentName = $this->utils->getPaymentNameFromId($userData['additional']['payment']['id']);
 
-        if (!$request->isDispatched() or !stristr($paymentName, 'klarna')) { // no klarna payment method
+        if (!$request->isDispatched() or !stristr($paymentName, 'fatchip_computop_klarna_')) { // no klarna payment method
             return;
         }
 
@@ -149,7 +149,7 @@ class KlarnaPayments extends AbstractSubscriber
         $userData = Shopware()->Modules()->Admin()->sGetUserData();
         $paymentName = $this->utils->getPaymentNameFromId($userData['additional']['payment']['id']);
 
-        if (!stristr($paymentName, 'klarna')) { // no klarna payment method
+        if (!stristr($paymentName, 'fatchip_computop_klarna_')) { // no klarna payment method
             return;
         }
 
@@ -172,7 +172,7 @@ class KlarnaPayments extends AbstractSubscriber
         $userData = Shopware()->Modules()->Admin()->sGetUserData();
         $paymentName = $this->utils->getPaymentNameFromId($userData['additional']['payment']['id']);
 
-        if (!stristr($paymentName, 'klarna')) { // no klarna payment method
+        if (!stristr($paymentName, 'fatchip_computop_klarna_')) { // no klarna payment method
             return;
         }
 


### PR DESCRIPTION
By narrow down the early exit checks in the subscriber from 'klarna' to 'fatchip_computop_klarna_' we make sure, that the computop plugin wont interfere with external klarna plugins.