### PR TITLE
fix plugin installer type

### DIFF
--- a/Controllers/Frontend/FatchipCTCreditCard.php
+++ b/Controllers/Frontend/FatchipCTCreditCard.php
@@ -69,11 +69,18 @@ class Shopware_Controllers_Frontend_FatchipCTCreditCard extends Shopware_Control
      */
     public function gatewayAction()
     {
-        $payment = $this->getPaymentClassForGatewayAction();
-        $params = $payment->getRedirectUrlParams();
-        $this->session->offsetSet('fatchipCTRedirectParams', $params);
-
-        $this->forward('iframe', 'FatchipCTCreditCard', null, array('fatchipCTRedirectURL' => $payment->getHTTPGetURL($params, $this->config['creditCardTemplate'])));
+        try {
+            $payment = $this->getPaymentClassForGatewayAction();
+            $payment->setUrlBack($this->router->assemble(['controller' => 'FatchipCTCreditCard', 'action' => 'failure', 'forceSecure' => true]));
+            $params = $payment->getRedirectUrlParams();
+            $this->session->offsetSet('fatchipCTRedirectParams', $params);
+            $this->forward('iframe', 'FatchipCTCreditCard', null, array('fatchipCTRedirectURL' => $payment->getHTTPGetURL($params)));
+        } catch (Exception $e) {
+            $ctError = [];
+            $ctError['CTErrorMessage'] = 'Bei der Verarbeitung Ihrer Adresse ist ein Fehler aufgetreten<BR>';
+            $ctError['CTErrorCode'] = 'Bitte prüfen Sie Straße und Hausnummer';
+            return $this->forward('confirm', 'checkout', null, ['CTError' => $ctError]);
+        }
     }
 
     /**

--- a/Controllers/Frontend/FatchipCTPayment.php
+++ b/Controllers/Frontend/FatchipCTPayment.php
@@ -163,10 +163,17 @@ abstract class Shopware_Controllers_Frontend_FatchipCTPayment extends Shopware_C
      */
     public function gatewayAction()
     {
-        $payment = $this->getPaymentClassForGatewayAction();
-        $params = $payment->getRedirectUrlParams();
-        $this->session->offsetSet('fatchipCTRedirectParams', $params);
-        $this->redirect($payment->getHTTPGetURL($params));
+        try {
+            $payment = $this->getPaymentClassForGatewayAction();
+            $params = $payment->getRedirectUrlParams();
+            $this->session->offsetSet('fatchipCTRedirectParams', $params);
+            $this->redirect($payment->getHTTPGetURL($params));
+        } catch (Exception $e) {
+            $ctError = [];
+            $ctError['CTErrorMessage'] = 'Bei der Verarbeitung Ihrer Adresse ist ein Fehler aufgetreten<BR>';
+            $ctError['CTErrorCode'] = 'Bitte prüfen Sie Straße und Hausnummer';
+            return $this->forward('confirm', 'checkout', null, ['CTError' => $ctError]);
+        }
     }
 
     /**

--- a/Subscribers/Frontend/Checkout.php
+++ b/Subscribers/Frontend/Checkout.php
@@ -148,22 +148,25 @@ class Checkout extends AbstractSubscriber
             $view->assign('CTError', $params['CTError']);
         }
 
-        if ($request->getActionName() == 'confirm' && (strpos($paymentName, fatchip_computop) === 0)) {
+        if ($request->getActionName() == 'confirm' && (strpos($paymentName, 'fatchip_computop') === 0)) {
             // check for address splitting errors and handle them here
             $util = new Util();
             $ctOrder = new CTOrder();
             try {
+                //handle expired session
+                if (!array_key_exists('billingaddress', $userData)
+                    || !array_key_exists('shippingaddress', $userData)
+                ) {
+                    throw new \Exception('Ihre Sitzung ist abgelaufen. Bitte loggen Sie sich erneut ein.');
+                }
                 $ctOrder->setBillingAddress($util->getCTAddress($userData['billingaddress']));
                 $ctOrder->setShippingAddress($util->getCTAddress($userData['shippingaddress']));
             } catch (\Exception $e) {
-
                 $ctError = [];
-                $ctError['CTErrorMessage'] = 'Bei der Verarbeitung Ihrer Adresse ist ein Fehler aufgetreten <BR>';
+                $ctError['CTErrorMessage'] = 'Bei der Verarbeitung Ihrer Adresse ist ein Fehler aufgetreten. <BR>';
                 $ctError['CTErrorCode'] = 'Bitte prüfen Sie Straße und Hausnummer';
-                //$subject->forward('shippingPayment', 'checkout', null, ['CTError' => $ctError]);
                 $view->assign('CTError', $ctError);
                 return;
-
             }
         }
     }

--- a/Views/responsive/frontend/checkout/confirm.tpl
+++ b/Views/responsive/frontend/checkout/confirm.tpl
@@ -4,7 +4,7 @@
     {$smarty.block.parent}
     <div>
         {if $CTError}
-            {include file="frontend/_includes/messages.tpl" content="{$CTError.CTErrorMessage}:{$CTError.CTErrorCode}" type="error" bold=false}
+            {include file="frontend/_includes/messages.tpl" content="{$CTError.CTErrorMessage} {$CTError.CTErrorCode}" type="error" bold=false}
         {/if}
     </div>
 {/block}

--- a/Views/responsive/frontend/checkout/creditcard_confirm.tpl
+++ b/Views/responsive/frontend/checkout/creditcard_confirm.tpl
@@ -1,5 +1,14 @@
 {extends file="parent:frontend/checkout/confirm.tpl"}
 
+{block name='frontend_checkout_confirm_error_messages'}
+    {$smarty.block.parent}
+    <div>
+        {if $CTError}
+            {include file="frontend/_includes/messages.tpl" content="{$CTError.CTErrorMessage}" type="error" bold=false}
+        {/if}
+    </div>
+{/block}
+
 {block name="frontend_checkout_confirm_information_wrapper"}
     {$smarty.block.parent}
 

--- a/Views/responsive/frontend/checkout/shipping_payment.tpl
+++ b/Views/responsive/frontend/checkout/shipping_payment.tpl
@@ -3,7 +3,7 @@
 {block name='frontend_account_payment_error_messages'}
     <div>
         {if $CTError}
-            {include file="frontend/_includes/messages.tpl" content="{$CTError.CTErrorMessage}:{$CTError.CTErrorCode}" type="error" bold=false}
+            {include file="frontend/_includes/messages.tpl" content="{$CTError.CTErrorMessage} {$CTError.CTErrorCode}" type="error" bold=false}
         {/if}
     </div>
     {$smarty.block.parent}

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,11 @@
   "name": "fatchip/plugin-shopware5-computop",
   "description": "FATCHIP Computop Payment Plugin",
   "license": "GPL-3.0",
-  "type": "shopware-plugin",
+  "type": "shopware-frontend-plugin",
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.2"
+  },
+  "extra": {
+    "installer-name": "FatchipCTPayment"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,8 @@
   },
   "extra": {
     "installer-name": "FatchipCTPayment"
+  },
+  "scripts": {
+    "post-root-package-install": "git submodule update --init"
   }
 }


### PR DESCRIPTION
The plugin is currently not installable via composer, since the installer type "shopware-plugin" is meant for shopware5+ plugins that are installed to custom/plugins. The installer type "shopware-frontend-plugin" will install the plugin to engine/Shopware/Plugins/Local/Frontend instead.
Also the plugin folder is generated from the package name by default, which doesn't match the actually expected plugin name (FatchipPluginShopware5Computop instead of FatchipCTPayment).
The installer-name override in the extra section fixes that. The resulting install path is engine/Shopware/Plugins/Local/Frontend/FatchipCTPayment.

In addition this PR adds a composer script that will install the Api submodule when the plugin is installed via composer.