### PR TITLE
Composer install support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,11 @@
   "name": "fatchip/plugin-shopware5-computop",
   "description": "FATCHIP Computop Payment Plugin",
   "license": "GPL-3.0",
-  "type": "shopware-plugin",
+  "type": "shopware-frontend-plugin",
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.2"
+  },
+  "extra": {
+    "installer-name": "FatchipCTPayment"
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,5 +8,8 @@
   },
   "extra": {
     "installer-name": "FatchipCTPayment"
+  },
+  "scripts": {
+    "post-root-package-install": "git submodule update --init --force"
   }
 }


### PR DESCRIPTION
The plugin is currently not installable via composer, since the installer type "shopware-plugin" is meant for shopware5+ plugins that are installed to custom/plugins. The installer type "shopware-frontend-plugin" will install the plugin to engine/Shopware/Plugins/Local/Frontend instead.
Also the plugin folder is generated from the package name by default, which doesn't match the actually expected plugin name (FatchipPluginShopware5Computop instead of FatchipCTPayment).
The installer-name override in the extra section fixes that. The resulting install path is engine/Shopware/Plugins/Local/Frontend/FatchipCTPayment.

In addition this PR adds a composer script that will install the Api submodule when the plugin is installed via composer.